### PR TITLE
Fix jar release and allow running it with java 17

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,7 @@ jobs:
 
       - name: Build .jar file
         if: ${{ matrix.os == 'ubuntu-latest' }}
-        run: ./gradlew fatJar --info --build-cache
+        run: ./gradlew shadowJar --info --build-cache
 
       - name: Build native distribution
         run: ./gradlew nativeDistribution --info --build-cache

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -82,8 +82,8 @@ spotless {
 }
 
 tasks {
-    withType<JavaCompile> { targetCompatibility = JavaVersion.VERSION_11.toString() }
-    withType<KotlinCompile> { compilerOptions { jvmTarget.set(JvmTarget.JVM_11) } }
+    withType<JavaCompile> { targetCompatibility = JavaVersion.VERSION_17.toString() }
+    withType<KotlinCompile> { compilerOptions { jvmTarget.set(JvmTarget.JVM_17) } }
 
     register("nativeDistribution") {
         dependsOn("packageDistributionForCurrentOS", "createChecksumsForNativeDistributions")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,7 @@
 import org.gradle.crypto.checksum.Checksum
 import org.jetbrains.compose.desktop.application.dsl.TargetFormat
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
     val kotlinVersion = "2.0.0"
@@ -80,6 +82,9 @@ spotless {
 }
 
 tasks {
+    withType<JavaCompile> { targetCompatibility = JavaVersion.VERSION_11.toString() }
+    withType<KotlinCompile> { compilerOptions { jvmTarget.set(JvmTarget.JVM_11) } }
+
     register("nativeDistribution") {
         dependsOn("packageDistributionForCurrentOS", "createChecksumsForNativeDistributions")
     }


### PR DESCRIPTION
See also https://github.com/StefanLobbenmeier/yt-dlp-compose/issues/53

Java 11 is required for androidx (hard requirement for jetpack compose)
Java 17 is required for mpfilepicker (we could get away with lower here maybe, but would require using another implementation for it)