### PR TITLE
Convert rate limit from kBytes to bytes before passing to yt-dlp

### DIFF
--- a/src/main/kotlin/de/lobbenmeier/stefan/downloadlist/business/YtDlpConfiguration.kt
+++ b/src/main/kotlin/de/lobbenmeier/stefan/downloadlist/business/YtDlpConfiguration.kt
@@ -19,7 +19,7 @@ fun Settings.toYtDlpConfiguration(): Array<String> =
 
             addArgument("--proxy", proxy)
             addArgument("--concurrent-fragments", concurrentFragments)
-            addArgument("--rate-limit", rateLimit)
+            addArgument("--rate-limit", rateLimit?.kilobytesToBytes())
             addArgument("--add-headers", header)
             addArgument("--cookies-from-browser", cookiesFromBrowser)
             addArgument("--cookies", cookiesFile)
@@ -44,3 +44,5 @@ fun Settings.toYtDlpConfiguration(): Array<String> =
             addArgument("--keep-video", keepUnmergedFiles)
         }
         .toTypedArray()
+
+private fun UInt.kilobytesToBytes() = this.times(1024u)

--- a/src/main/kotlin/de/lobbenmeier/stefan/downloadlist/business/YtDlpConfiguration.kt
+++ b/src/main/kotlin/de/lobbenmeier/stefan/downloadlist/business/YtDlpConfiguration.kt
@@ -45,4 +45,4 @@ fun Settings.toYtDlpConfiguration(): Array<String> =
         }
         .toTypedArray()
 
-private fun UInt.kilobytesToBytes() = this.times(1024u)
+fun UInt.kilobytesToBytes() = this.times(1024u)

--- a/src/test/kotlin/de/lobbenmeier/stefan/downloadlist/business/YtDlpConfigurationKtTest.kt
+++ b/src/test/kotlin/de/lobbenmeier/stefan/downloadlist/business/YtDlpConfigurationKtTest.kt
@@ -1,0 +1,14 @@
+package de.lobbenmeier.stefan.downloadlist.business
+
+import de.lobbenmeier.stefan.settings.business.createEmptySettings
+import io.kotest.core.spec.style.AnnotationSpec
+import io.kotest.matchers.collections.shouldContainInOrder
+
+class YtDlpConfigurationKtTest : AnnotationSpec() {
+
+    @Test
+    fun convertsKilobytesToBytesForRateLimit() {
+        val settings = createEmptySettings().copy(rateLimit = 1u)
+        settings.toYtDlpConfiguration().shouldContainInOrder("--rate-limit", "1024")
+    }
+}


### PR DESCRIPTION
Fixes https://github.com/StefanLobbenmeier/yt-dlp-compose/issues/149