### PR TITLE
Stop releasing the sha256, its now a Github feature

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,7 +68,6 @@ jobs:
           tag_name: ${{ env.VERSION }}
           files: |
             build/fatJar/*
-            build/checksums/*
             build/compose/binaries/main/*
             build/compose/binaries/main/*/*
           generate_release_notes: true
@@ -80,7 +79,6 @@ jobs:
           make_latest: true
           tag_name: ${{ env.VERSION }}
           files: |
-            build/checksums/*
             build/compose/binaries/main/*
             build/compose/binaries/main/*/*
           generate_release_notes: true


### PR DESCRIPTION
See https://github.blog/changelog/2025-06-03-releases-now-expose-digests-for-release-assets/