### PR TITLE
Fix release for macos-intel

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,8 +18,8 @@ jobs:
       matrix:
         os:
           # https://github.com/actions/runner-images?tab=readme-ov-file#available-images
-          - 'macos-13' # x64
-          - 'macos-14' # arm
+          - 'macos-latest-large' # x64
+          - 'macos-latest' # arm
           - 'windows-latest'
           - 'ubuntu-latest'
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
macos-13 was deprecated, lets hope that this naming scheme works, should get the correct images according to https://github.com/actions/runner-images?tab=readme-ov-file#available-images