### PR TITLE
Avoid duplicate release notes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -81,4 +81,4 @@ jobs:
           files: |
             build/compose/binaries/main/*
             build/compose/binaries/main/*/*
-          generate_release_notes: true
+          generate_release_notes: false # only the linux job will generate notes


### PR DESCRIPTION
It seems there was some update of softprops/action-gh-release@v2 that make my release notes repeat four times, this should fix that